### PR TITLE
Mobile UX, file sharing, queue, caching

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,3 +49,11 @@ This repo is a Linux-first companion UI for continuing Codex CLI TUI sessions on
   - Install: `python3 -m pip install -e .`
   - Run server: `codoxear-server` or `python3 -m codoxear.server`
   - Broker: `codoxear-broker -- <codex args>`
+
+## Ops notes
+
+- Restarting `codoxear.server` does **not** lose session content. Sessions live in Codex rollout logs on disk; the server only reads them.
+- To avoid losing live sessions, **only** stop the server process. Do **not** kill `codoxear-broker` or the Codex process.
+- Safe restart example (server only):
+  - `pgrep -f "python3 -m codoxear.server" | xargs -r kill`
+  - `CODEX_WEB_PASSWORD=... CODEX_WEB_PORT=13780 CODEX_WEB_HOST=0.0.0.0 nohup python3 -m codoxear.server >/tmp/codoxear-13780.log 2>&1 &`

--- a/codoxear/broker.py
+++ b/codoxear/broker.py
@@ -878,6 +878,14 @@ class Broker:
                         if not st:
                             resp = {"error": "no state"}
                         else:
+                            now_ts = _now()
+                            st.pending_calls.clear()
+                            st.busy = True
+                            st.turn_open = True
+                            st.turn_has_completion_candidate = False
+                            st.last_interrupt_hint_ts = 0.0
+                            if now_ts > st.last_turn_activity_ts:
+                                st.last_turn_activity_ts = now_ts
                             fd = st.pty_master_fd
                             resp = {"queued": False, "queue_len": len(st.queue)}
                     if fd is not None:

--- a/codoxear/static/app.css
+++ b/codoxear/static/app.css
@@ -995,17 +995,21 @@ input[type="text"] {
         }
         #threadTitle {
           max-width: 100%;
+          font-size: 15px;
+          line-height: 1.2;
         }
         .pill {
-          align-items: flex-start;
+          align-items: center;
           gap: 8px;
         }
         .titleRow {
-          flex-wrap: wrap;
-          gap: 6px;
+          display: grid;
+          grid-template-columns: 1fr auto;
+          align-items: center;
+          gap: 8px;
         }
         .topMeta {
-          width: 100%;
+          justify-content: flex-end;
         }
         .status-chip {
           font-size: 11px;
@@ -1032,15 +1036,17 @@ input[type="text"] {
           max-width: 88%;
         }
         .topActions {
+          display: grid;
+          grid-template-columns: repeat(auto-fit, minmax(52px, 1fr));
           gap: 6px;
-          justify-content: flex-start;
-          flex-wrap: nowrap;
-          overflow-x: auto;
-          -webkit-overflow-scrolling: touch;
-          padding-bottom: 2px;
+          padding: 6px;
+          border: 1px solid var(--border);
+          border-radius: 12px;
+          background: rgba(15, 23, 42, 0.03);
         }
-        .topActions::-webkit-scrollbar {
-          display: none;
+        .topActions .icon-btn {
+          width: 100%;
+          height: 34px;
         }
         .fileViewer {
           width: 100vw;

--- a/codoxear/static/app.css
+++ b/codoxear/static/app.css
@@ -308,11 +308,18 @@
 	        border-radius: 10px;
 	        position: relative;
 	      }
-	      .icon-btn.active {
-	        border-color: rgba(37, 99, 235, 0.5);
-	        background: rgba(37, 99, 235, 0.08);
-	        color: var(--accent);
-	      }
+      .icon-btn.active {
+        border-color: rgba(37, 99, 235, 0.5);
+        background: rgba(37, 99, 235, 0.08);
+        color: var(--accent);
+      }
+      .icon-btn.text-btn {
+        width: auto;
+        min-width: 46px;
+        padding: 0 10px;
+        font-size: 12px;
+        line-height: 1;
+      }
 	      .icon {
 	        width: 18px;
 	        height: 18px;
@@ -333,6 +340,9 @@
         text-align: center;
         display: none;
         box-shadow: 0 6px 14px rgba(15, 23, 42, 0.16);
+      }
+      .queueBadge {
+        background: rgba(245, 158, 11, 0.95);
       }
 
       .status-chip {
@@ -784,6 +794,11 @@ input[type="text"] {
         justify-content: space-between;
         gap: 10px;
       }
+      .fileViewerHeader .actions {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
       .filePathRow {
         display: flex;
         gap: 8px;
@@ -807,6 +822,79 @@ input[type="text"] {
         flex: 1 1 auto;
         min-height: 120px;
         -webkit-overflow-scrolling: touch;
+      }
+      .fileViewer.wrap .fileContent {
+        white-space: pre-wrap;
+        word-break: break-word;
+        overflow-wrap: anywhere;
+      }
+      .queueViewer {
+        display: none;
+        position: fixed;
+        left: 50%;
+        top: calc(50% + var(--vvTop, 0px));
+        transform: translate(-50%, -50%);
+        z-index: 80;
+        width: min(92vw, 520px);
+        max-height: calc(var(--appH, 100dvh) - 24px);
+        background: var(--panel);
+        border: 1px solid var(--border);
+        border-radius: 14px;
+        box-shadow: 0 24px 60px rgba(15, 23, 42, 0.28);
+        padding: 12px;
+        flex-direction: column;
+        gap: 10px;
+        box-sizing: border-box;
+      }
+      .queueHeader {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 10px;
+      }
+      .queueList {
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+        overflow: auto;
+        -webkit-overflow-scrolling: touch;
+      }
+      .queueItem {
+        display: flex;
+        gap: 8px;
+        align-items: flex-start;
+      }
+      .queueText {
+        flex: 1 1 auto;
+        min-height: 64px;
+        max-height: 160px;
+        resize: vertical;
+        font-size: 13px;
+      }
+      .sendChoice {
+        display: none;
+        position: fixed;
+        left: 50%;
+        top: calc(50% + var(--vvTop, 0px));
+        transform: translate(-50%, -50%);
+        z-index: 80;
+        width: min(92vw, 420px);
+        background: var(--panel);
+        border: 1px solid var(--border);
+        border-radius: 14px;
+        box-shadow: 0 24px 60px rgba(15, 23, 42, 0.28);
+        padding: 12px;
+        flex-direction: column;
+        gap: 10px;
+        box-sizing: border-box;
+      }
+      .sendChoiceActions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+      }
+      .sendChoiceActions button {
+        flex: 1 1 auto;
       }
 		      .backdrop {
 		        display: none;
@@ -916,6 +1004,17 @@ input[type="text"] {
           display: none;
         }
         .fileViewer {
+          width: 100vw;
+          max-height: none;
+          left: 0;
+          right: 0;
+          top: var(--vvTop, 0px);
+          bottom: 0;
+          transform: none;
+          border-radius: 0;
+          padding: calc(10px + env(safe-area-inset-top)) 10px calc(10px + env(safe-area-inset-bottom)) 10px;
+        }
+        .queueViewer {
           width: 100vw;
           max-height: none;
           left: 0;

--- a/codoxear/static/app.css
+++ b/codoxear/static/app.css
@@ -263,12 +263,37 @@
         min-width: 0;
         flex: 1 1 auto;
       }
+      .titleWrap {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        min-width: 0;
+        flex: 1 1 auto;
+      }
+      .titleRow {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        min-width: 0;
+      }
       #threadTitle {
         font-weight: 650;
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
         max-width: 56vw;
+      }
+      .titleRow #threadTitle {
+        flex: 1 1 auto;
+        min-width: 0;
+        max-width: none;
+      }
+      .topMeta {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        flex: 0 0 auto;
+        flex-wrap: wrap;
       }
       .toast {
         margin-top: 4px;
@@ -280,6 +305,9 @@
         flex: 0 0 auto;
         flex-wrap: wrap;
         justify-content: flex-end;
+      }
+      .topActions {
+        align-items: center;
       }
       button {
         border: 1px solid var(--border);
@@ -968,6 +996,17 @@ input[type="text"] {
         #threadTitle {
           max-width: 100%;
         }
+        .pill {
+          align-items: flex-start;
+          gap: 8px;
+        }
+        .titleRow {
+          flex-wrap: wrap;
+          gap: 6px;
+        }
+        .topMeta {
+          width: 100%;
+        }
         .status-chip {
           font-size: 11px;
           padding: 3px 8px;
@@ -992,7 +1031,7 @@ input[type="text"] {
         .msg {
           max-width: 88%;
         }
-        .actions {
+        .topActions {
           gap: 6px;
           justify-content: flex-start;
           flex-wrap: nowrap;
@@ -1000,7 +1039,7 @@ input[type="text"] {
           -webkit-overflow-scrolling: touch;
           padding-bottom: 2px;
         }
-        .actions::-webkit-scrollbar {
+        .topActions::-webkit-scrollbar {
           display: none;
         }
         .fileViewer {

--- a/codoxear/static/app.css
+++ b/codoxear/static/app.css
@@ -275,6 +275,7 @@
         align-items: center;
         gap: 10px;
         min-width: 0;
+        flex-wrap: nowrap;
       }
       #threadTitle {
         font-weight: 650;
@@ -293,7 +294,7 @@
         align-items: center;
         gap: 6px;
         flex: 0 0 auto;
-        flex-wrap: wrap;
+        flex-wrap: nowrap;
       }
       .toast {
         margin-top: 4px;
@@ -1003,13 +1004,15 @@ input[type="text"] {
           gap: 8px;
         }
         .titleRow {
-          display: grid;
-          grid-template-columns: 1fr auto;
+          display: flex;
           align-items: center;
           gap: 8px;
+          flex-wrap: nowrap;
         }
         .topMeta {
           justify-content: flex-end;
+          flex-wrap: nowrap;
+          white-space: nowrap;
         }
         .status-chip {
           font-size: 11px;

--- a/codoxear/static/app.css
+++ b/codoxear/static/app.css
@@ -1036,16 +1036,16 @@ input[type="text"] {
           max-width: 88%;
         }
         .topActions {
-          display: grid;
-          grid-template-columns: repeat(auto-fit, minmax(52px, 1fr));
-          gap: 6px;
-          padding: 6px;
-          border: 1px solid var(--border);
-          border-radius: 12px;
-          background: rgba(15, 23, 42, 0.03);
+          display: flex;
+          gap: 8px;
+          flex-wrap: wrap;
+          justify-content: flex-start;
+          padding: 0;
+          border: none;
+          background: transparent;
         }
         .topActions .icon-btn {
-          width: 100%;
+          width: 34px;
           height: 34px;
         }
         .fileViewer {

--- a/codoxear/static/app.css
+++ b/codoxear/static/app.css
@@ -13,22 +13,34 @@
         --bubble-assistant: #ffffff;
       }
 
+      *,
+      *::before,
+      *::after {
+        box-sizing: border-box;
+      }
+
       html,
       body {
         height: 100%;
+        width: 100%;
+        max-width: 100%;
         margin: 0;
         font-family: Inter, ui-sans-serif, system-ui, -apple-system, "Segoe UI Variable", "Segoe UI", Roboto, "Helvetica Neue", Arial,
           "Noto Sans", "Liberation Sans", sans-serif;
         font-optical-sizing: auto;
         -webkit-text-size-adjust: 100%;
         text-size-adjust: 100%;
+        -webkit-tap-highlight-color: transparent;
         background: var(--bg);
         color: var(--text);
         overflow: hidden;
+        overflow-x: hidden;
       }
 
       #root {
         height: 100%;
+        width: 100%;
+        max-width: 100%;
       }
 
       #bottomSentinel {
@@ -44,6 +56,8 @@
         top: var(--vvTop, 0px);
         left: 0;
         right: 0;
+        width: 100vw;
+        max-width: 100vw;
         height: 100svh;
         height: 100dvh;
         height: var(--appH, 100dvh);
@@ -112,6 +126,7 @@
         display: flex;
         gap: 12px;
         align-items: stretch;
+        touch-action: manipulation;
       }
       .session.active {
         border-color: rgba(37, 99, 235, 0.6);
@@ -128,6 +143,39 @@
         display: flex;
         align-items: center;
         justify-content: center;
+        gap: 6px;
+      }
+      .sessionFiles {
+        margin-top: 6px;
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+      }
+      .sessionFilesLabel {
+        font-size: 11px;
+        color: var(--muted);
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+      }
+      .sessionFile {
+        text-align: left;
+        padding: 6px 8px;
+        border-radius: 8px;
+        font-size: 12px;
+        line-height: 1.2;
+        border: 1px solid var(--border);
+        background: #ffffff;
+        color: var(--text);
+        overflow: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+        touch-action: manipulation;
+      }
+      .sessionFile:hover {
+        background: rgba(15, 23, 42, 0.04);
+      }
+      .sessionFilesMore {
+        font-size: 11px;
       }
       .sessionAction > .icon-btn {
         width: 36px;
@@ -194,6 +242,7 @@
         flex-direction: column;
         height: 100%;
         min-height: 0;
+        min-width: 0;
       }
       .topbar {
         padding: calc(10px + env(safe-area-inset-top)) 12px 10px 12px;
@@ -204,12 +253,15 @@
         align-items: center;
         justify-content: space-between;
         gap: 12px;
+        flex-wrap: wrap;
+        row-gap: 6px;
       }
       .pill {
         display: inline-flex;
         align-items: center;
         gap: 10px;
         min-width: 0;
+        flex: 1 1 auto;
       }
       #threadTitle {
         font-weight: 650;
@@ -226,6 +278,8 @@
         display: flex;
         gap: 8px;
         flex: 0 0 auto;
+        flex-wrap: wrap;
+        justify-content: flex-end;
       }
       button {
         border: 1px solid var(--border);
@@ -304,12 +358,14 @@
         min-height: 0;
         position: relative;
         overflow: hidden;
+        min-width: 0;
       }
       .chat {
         height: 100%;
         padding: 14px 12px;
         overflow: auto;
         overscroll-behavior: contain;
+        -webkit-overflow-scrolling: touch;
       }
       .chat {
         overflow-x: hidden;
@@ -319,6 +375,7 @@
         margin: 0 auto;
         display: flex;
         flex-direction: column;
+        width: 100%;
       }
       .day-sep {
         align-self: center;
@@ -455,6 +512,10 @@
         text-decoration-thickness: 1px;
         text-underline-offset: 2px;
       }
+      .md img {
+        max-width: 100%;
+        height: auto;
+      }
       .md code {
         font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
         font-size: 13px;
@@ -544,13 +605,14 @@
         padding: 6px 10px;
         white-space: normal;
       }
-      textarea,
-      input[type="password"] {
-        width: 100%;
-        box-sizing: border-box;
-        border: 1px solid var(--border);
-        background: #ffffff;
-        color: var(--text);
+textarea,
+input[type="password"],
+input[type="text"] {
+  width: 100%;
+  box-sizing: border-box;
+  border: 1px solid var(--border);
+  background: #ffffff;
+  color: var(--text);
         border-radius: 18px;
         padding: 10px 12px;
         font-family: inherit;
@@ -682,15 +744,70 @@
 	        width: 16px;
 	        height: 16px;
 	      }
-	      .harnessMenu textarea {
-	        min-height: 160px;
-	        height: 160px;
-	        max-height: 320px;
-	        overflow-y: auto;
-	        border-radius: 14px;
-	        resize: vertical;
-	      }
+      .harnessMenu textarea {
+        min-height: 160px;
+        height: 160px;
+        max-height: 320px;
+        overflow-y: auto;
+        border-radius: 14px;
+        resize: vertical;
+      }
 
+      .modalBackdrop {
+        display: none;
+        position: fixed;
+        inset: 0;
+        background: rgba(15, 23, 42, 0.45);
+        z-index: 70;
+      }
+      .fileViewer {
+        display: none;
+        position: fixed;
+        left: 50%;
+        top: calc(50% + var(--vvTop, 0px));
+        transform: translate(-50%, -50%);
+        z-index: 80;
+        width: min(92vw, 980px);
+        max-height: calc(var(--appH, 100dvh) - 24px);
+        background: var(--panel);
+        border: 1px solid var(--border);
+        border-radius: 16px;
+        box-shadow: 0 24px 60px rgba(15, 23, 42, 0.28);
+        padding: 12px;
+        flex-direction: column;
+        gap: 10px;
+        box-sizing: border-box;
+      }
+      .fileViewerHeader {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 10px;
+      }
+      .filePathRow {
+        display: flex;
+        gap: 8px;
+        align-items: center;
+      }
+      .filePathRow input[type="text"] {
+        flex: 1 1 auto;
+        min-width: 0;
+      }
+      .fileContent {
+        margin: 0;
+        padding: 12px;
+        border-radius: 12px;
+        border: 1px solid rgba(15, 23, 42, 0.1);
+        background: #0b1220;
+        color: #e5e7eb;
+        overflow: auto;
+        white-space: pre;
+        font-size: 12px;
+        line-height: 1.4;
+        flex: 1 1 auto;
+        min-height: 120px;
+        -webkit-overflow-scrolling: touch;
+      }
 		      .backdrop {
 		        display: none;
 		        position: absolute;
@@ -757,9 +874,11 @@
         .topbar {
           padding: calc(8px + env(safe-area-inset-top)) 10px 8px 10px;
           gap: 10px;
+          align-items: stretch;
+          flex-direction: column;
         }
         #threadTitle {
-          max-width: 44vw;
+          max-width: 100%;
         }
         .status-chip {
           font-size: 11px;
@@ -787,6 +906,58 @@
         }
         .actions {
           gap: 6px;
+          justify-content: flex-start;
+          flex-wrap: nowrap;
+          overflow-x: auto;
+          -webkit-overflow-scrolling: touch;
+          padding-bottom: 2px;
+        }
+        .actions::-webkit-scrollbar {
+          display: none;
+        }
+        .fileViewer {
+          width: 100vw;
+          max-height: none;
+          left: 0;
+          right: 0;
+          top: var(--vvTop, 0px);
+          bottom: 0;
+          transform: none;
+          border-radius: 0;
+          padding: calc(10px + env(safe-area-inset-top)) 10px calc(10px + env(safe-area-inset-bottom)) 10px;
+        }
+        .sessionFilesLabel {
+          font-size: 10px;
+        }
+        .sessionFile {
+          font-size: 11px;
+        }
+        .fileContent {
+          font-size: 11px;
+        }
+      }
+
+      @media (hover: none) and (pointer: coarse) {
+        button {
+          min-height: 40px;
+          touch-action: manipulation;
+        }
+        .icon-btn {
+          width: 40px;
+          height: 40px;
+        }
+        .composer {
+          --composerCtl: 40px;
+        }
+        textarea,
+        input[type="password"] {
+          font-size: 16px;
+        }
+        .composer textarea {
+          font-size: 16px;
+        }
+        .session {
+          padding: 12px;
         }
       }
 

--- a/codoxear/static/app.js
+++ b/codoxear/static/app.js
@@ -632,11 +632,12 @@
 			          el("textarea", { id: "harnessRequest", "aria-label": "Additional request for harness prompt" }),
 			        ]);
 
+        const topMeta = el("div", { class: "topMeta" }, [statusChip, ctxChip]);
+        const titleRow = el("div", { class: "titleRow" }, [titleLabel, topMeta]);
+        const titleWrap = el("div", { class: "titleWrap" }, [titleRow, toast]);
         const topbar = el("div", { class: "topbar" }, [
-          el("div", { class: "pill" }, [toggleSidebarBtn, el("div", {}, [titleLabel, toast])]),
-          el("div", { class: "actions" }, [
-            statusChip,
-            ctxChip,
+          el("div", { class: "pill" }, [toggleSidebarBtn, titleWrap]),
+          el("div", { class: "actions topActions" }, [
             renameBtn,
             fileBtn,
             interruptBtn,

--- a/codoxear/static/app.js
+++ b/codoxear/static/app.js
@@ -200,17 +200,18 @@
         if (alias) return alias;
         const cwdName = baseName(s.cwd);
         if (cwdName) return cwdName;
-        return s.session_id ? String(s.session_id) : "";
+        const ts = typeof s.updated_ts === "number" && Number.isFinite(s.updated_ts)
+          ? s.updated_ts
+          : typeof s.start_ts === "number" && Number.isFinite(s.start_ts)
+            ? s.start_ts
+            : 0;
+        return ts ? `Session ${fmtTs(ts)}` : "Session";
       }
 
       function sessionTitleWithId(s) {
         if (!s || typeof s !== "object") return "No session selected";
         const name = sessionDisplayName(s);
-        const sid = s.session_id ? String(s.session_id) : "";
-        if (!name) return sid || "No session selected";
-        if (!sid) return name;
-        if (name === sid) return shortSessionId(sid);
-        return `${name} (${sid.slice(0, 8)})`;
+        return name || "No session selected";
       }
 
       function escapeHtml(s) {
@@ -1235,9 +1236,8 @@
 		              el("div", { class: "titleLine", text: title, title: s.cwd || "" }),
 		              el("div", {}, badges),
 		            ]);
-	            const pid = s.pid ? String(s.pid) : "?";
               const updatedTs = typeof s.updated_ts === "number" && Number.isFinite(s.updated_ts) ? s.updated_ts : s.start_ts;
-	            const meta = el("div", { class: "muted subLine", text: `id ${shortSessionId(s.session_id)}  pid ${pid}  last ${fmtTs(updatedTs)}` });
+	            const meta = el("div", { class: "muted subLine", text: updatedTs ? `last ${fmtTs(updatedTs)}` : "" });
             const mainCol = el("div", { class: "sessionMain" }, [top, meta]);
             if (selected === s.session_id && files.length) {
               const maxShow = 5;

--- a/scripts/codoxear-resume
+++ b/scripts/codoxear-resume
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_DIR="${CODEX_WEB_APP_DIR:-$HOME/.local/share/codoxear}"
+SOCK_DIR="${APP_DIR}/socks"
+
+usage() {
+  cat <<'EOF'
+Usage: codoxear-resume [--list] [--last] [--id <session_id>] [--web | --terminal]
+
+Interactive helper to resume Codex sessions from Codoxear metadata.
+
+Options:
+  --list        List available sessions and exit
+  --last        Resume most recent session via codex
+  --id <id>     Resume specific session id
+  --web         Show only web-owned sessions
+  --terminal    Show only terminal-owned sessions
+EOF
+}
+
+if ! command -v codex >/dev/null 2>&1; then
+  echo "error: codex CLI not found in PATH" >&2
+  exit 1
+fi
+
+mode="interactive"
+filter_owner=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --last)
+      exec codex resume --last
+      ;;
+    --id)
+      if [[ -z "${2:-}" ]]; then
+        echo "error: --id requires a session id" >&2
+        exit 1
+      fi
+      exec codex resume "$2"
+      ;;
+    --list)
+      mode="list"
+      shift
+      ;;
+    --web)
+      filter_owner="web"
+      shift
+      ;;
+    --terminal)
+      filter_owner="terminal"
+      shift
+      ;;
+    *)
+      echo "error: unknown argument $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ ! -d "$SOCK_DIR" ]]; then
+  echo "error: no sessions dir at $SOCK_DIR" >&2
+  exit 1
+fi
+
+list_sessions() {
+  SOCK_DIR="$SOCK_DIR" FILTER_OWNER="$filter_owner" python3 - <<'PY'
+import json
+import os
+import time
+from pathlib import Path
+
+sock_dir = Path(os.environ["SOCK_DIR"])
+filter_owner = os.environ.get("FILTER_OWNER", "").strip()
+items = []
+for meta_path in sorted(sock_dir.glob("*.json")):
+    try:
+        meta = json.loads(meta_path.read_text(encoding="utf-8"))
+    except Exception:
+        continue
+    sid = meta.get("session_id") or meta_path.stem
+    if not isinstance(sid, str) or not sid.strip():
+        sid = meta_path.stem
+    owner = meta.get("owner") if isinstance(meta.get("owner"), str) else "terminal"
+    if filter_owner and owner != filter_owner:
+        continue
+    cwd = meta.get("cwd") if isinstance(meta.get("cwd"), str) else "?"
+    start_ts = meta.get("start_ts")
+    ts = float(start_ts) if isinstance(start_ts, (int, float)) else 0.0
+    start = time.strftime("%Y-%m-%d %H:%M", time.localtime(ts)) if ts > 0 else "?"
+    items.append((sid, owner, cwd, start, ts))
+
+items.sort(key=lambda x: x[4], reverse=True)
+for i, (sid, owner, cwd, start, _ts) in enumerate(items, 1):
+    print(f"{i}\t{sid}\t{owner}\t{cwd}\t{start}")
+PY
+}
+
+lines="$(list_sessions)"
+if [[ -z "$lines" ]]; then
+  echo "no sessions found in $SOCK_DIR" >&2
+  exit 1
+fi
+
+if [[ "$mode" == "list" ]]; then
+  printf "Idx\tSession ID\tOwner\tCWD\tStarted\n"
+  printf "%s\n" "$lines" | sed 's/\t/  /g'
+  exit 0
+fi
+
+printf "Idx  Session ID                           Owner     CWD                           Started\n"
+printf "%s\n" "$lines" | awk -F'\t' '{printf "%-4s %-36s %-9s %-28s %s\n", $1, $2, $3, $4, $5}'
+printf "\nSelect session number (blank to cancel): "
+read -r choice
+if [[ -z "${choice// }" ]]; then
+  exit 0
+fi
+if ! [[ "$choice" =~ ^[0-9]+$ ]]; then
+  echo "error: invalid choice" >&2
+  exit 1
+fi
+
+sid="$(printf "%s\n" "$lines" | awk -F'\t' -v n="$choice" '$1==n {print $2; exit}')"
+if [[ -z "$sid" ]]; then
+  echo "error: no session for selection $choice" >&2
+  exit 1
+fi
+
+exec codex resume "$sid"


### PR DESCRIPTION
## Summary\n- Improve mobile UI layout and controls, add session rename, duplicate, and file viewer workflows.\n- Add file viewer API with history; share file history across sessions with same workspace.\n- Add local message queue with persistence and queued message editor.\n- Add recent-message cache to speed initial load and reduce history fetches; keep log-order rendering and dedup.\n- Add helper script to resume sessions from Codoxear metadata.\n\n## Notes\n- Includes broker busy-state fix for web sends.\n- Adds cache versioning (v2) so old caches auto-reset.\n\nPlease let me know if you prefer smaller/stacked PRs.