### PR TITLE
Backend: file history + broker busy fix + resume helper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,3 +49,11 @@ This repo is a Linux-first companion UI for continuing Codex CLI TUI sessions on
   - Install: `python3 -m pip install -e .`
   - Run server: `codoxear-server` or `python3 -m codoxear.server`
   - Broker: `codoxear-broker -- <codex args>`
+
+## Ops notes
+
+- Restarting `codoxear.server` does **not** lose session content. Sessions live in Codex rollout logs on disk; the server only reads them.
+- To avoid losing live sessions, **only** stop the server process. Do **not** kill `codoxear-broker` or the Codex process.
+- Safe restart example (server only):
+  - `pgrep -f "python3 -m codoxear.server" | xargs -r kill`
+  - `CODEX_WEB_PASSWORD=... CODEX_WEB_PORT=13780 CODEX_WEB_HOST=0.0.0.0 nohup python3 -m codoxear.server >/tmp/codoxear-13780.log 2>&1 &`

--- a/codoxear/broker.py
+++ b/codoxear/broker.py
@@ -878,6 +878,14 @@ class Broker:
                         if not st:
                             resp = {"error": "no state"}
                         else:
+                            now_ts = _now()
+                            st.pending_calls.clear()
+                            st.busy = True
+                            st.turn_open = True
+                            st.turn_has_completion_candidate = False
+                            st.last_interrupt_hint_ts = 0.0
+                            if now_ts > st.last_turn_activity_ts:
+                                st.last_turn_activity_ts = now_ts
                             fd = st.pty_master_fd
                             resp = {"queued": False, "queue_len": len(st.queue)}
                     if fd is not None:

--- a/codoxear/server.py
+++ b/codoxear/server.py
@@ -95,6 +95,8 @@ STATE_PATH = APP_DIR / "state.json"
 HMAC_SECRET_PATH = APP_DIR / "hmac_secret"
 UPLOAD_DIR = APP_DIR / "uploads"
 HARNESS_PATH = APP_DIR / "harness.json"
+ALIAS_PATH = APP_DIR / "session_aliases.json"
+FILE_HISTORY_PATH = APP_DIR / "session_files.json"
 
 _DOTENV = (Path.cwd() / ".env").resolve()
 if _DOTENV.exists():
@@ -126,6 +128,8 @@ CHAT_INDEX_INCREMENT_BYTES = int(os.environ.get("CODEX_WEB_CHAT_INDEX_INCREMENT_
 CHAT_INDEX_RESEED_THRESHOLD_BYTES = int(os.environ.get("CODEX_WEB_CHAT_INDEX_RESEED_THRESHOLD_BYTES", str(16 * 1024 * 1024)))
 CHAT_INDEX_MAX_EVENTS = int(os.environ.get("CODEX_WEB_CHAT_INDEX_MAX_EVENTS", "12000"))
 METRICS_WINDOW = int(os.environ.get("CODEX_WEB_METRICS_WINDOW", "256"))
+FILE_READ_MAX_BYTES = int(os.environ.get("CODEX_WEB_FILE_READ_MAX_BYTES", str(2 * 1024 * 1024)))
+FILE_HISTORY_MAX = int(os.environ.get("CODEX_WEB_FILE_HISTORY_MAX", "20"))
 HARNESS_PROMPT_PREFIX = """Unattended-mode instructions (optimize for 8+ hours, minimal turns, minimal repetition, maximal progress)
 
 - Maintain three live lists: Deliverables, Next actions, Parked questions.
@@ -475,6 +479,18 @@ def _safe_read_text(path: Path, max_bytes: int = 512 * 1024) -> str:
         return ""
 
 
+def _read_text_file_strict(path: Path, *, max_bytes: int) -> tuple[str, int]:
+    st = path.stat()
+    size = int(st.st_size)
+    if size > max_bytes:
+        raise ValueError(f"file too large (max {max_bytes} bytes)")
+    data = path.read_bytes()
+    if b"\x00" in data:
+        raise ValueError("binary file not supported")
+    text = data.decode("utf-8", errors="replace")
+    return text, size
+
+
 def _safe_filename(name: str) -> str:
     out = []
     for ch in name:
@@ -484,6 +500,18 @@ def _safe_filename(name: str) -> str:
     if not s:
         return "image"
     return s[:96]
+
+
+def _clean_alias(name: str) -> str:
+    if not isinstance(name, str):
+        return ""
+    # Collapse whitespace and cap length to keep titles readable.
+    cleaned = " ".join(name.split()).strip()
+    if not cleaned:
+        return ""
+    if len(cleaned) > 80:
+        cleaned = cleaned[:80].rstrip()
+    return cleaned
 
 
 def _iter_session_logs() -> list[Path]:
@@ -655,10 +683,14 @@ class SessionManager:
         self._stop = threading.Event()
         self._last_discover_ts = 0.0
         self._harness: dict[str, dict[str, Any]] = {}
+        self._aliases: dict[str, str] = {}
+        self._files: dict[str, list[str]] = {}
         self._harness_last_injected: dict[str, float] = {}
         self._harness_last_injected_scope: dict[str, float] = {}
         self._discover_existing(force=True)
         self._load_harness()
+        self._load_aliases()
+        self._load_files()
         self._harness_thr = threading.Thread(target=self._harness_loop, name="harness", daemon=True)
         self._harness_thr.start()
 
@@ -722,6 +754,192 @@ class SessionManager:
         tmp = HARNESS_PATH.with_suffix(".json.tmp")
         tmp.write_text(json.dumps(obj, ensure_ascii=False, sort_keys=True, indent=2) + "\n", encoding="utf-8")
         os.replace(tmp, HARNESS_PATH)
+
+    def _load_aliases(self) -> None:
+        try:
+            raw = ALIAS_PATH.read_text(encoding="utf-8")
+        except FileNotFoundError:
+            return
+        obj = json.loads(raw)
+        if not isinstance(obj, dict):
+            raise ValueError("invalid session_aliases.json (expected object)")
+        cleaned: dict[str, str] = {}
+        for sid, v in obj.items():
+            if not isinstance(sid, str) or not sid:
+                continue
+            if not isinstance(v, str):
+                continue
+            alias = _clean_alias(v)
+            if alias:
+                cleaned[sid] = alias
+        with self._lock:
+            self._aliases = cleaned
+
+    def _save_aliases(self) -> None:
+        with self._lock:
+            obj = dict(self._aliases)
+        os.makedirs(APP_DIR, exist_ok=True)
+        tmp = ALIAS_PATH.with_suffix(".json.tmp")
+        tmp.write_text(json.dumps(obj, ensure_ascii=False, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+        os.replace(tmp, ALIAS_PATH)
+
+    def alias_set(self, session_id: str, name: str) -> str:
+        alias = _clean_alias(name)
+        with self._lock:
+            if session_id not in self._sessions:
+                raise KeyError("unknown session")
+            if alias:
+                self._aliases[session_id] = alias
+            else:
+                self._aliases.pop(session_id, None)
+        self._save_aliases()
+        return alias
+
+    def alias_get(self, session_id: str) -> str:
+        with self._lock:
+            alias = self._aliases.get(session_id)
+        return alias if isinstance(alias, str) else ""
+
+    def alias_clear(self, session_id: str) -> None:
+        with self._lock:
+            if session_id not in self._aliases:
+                return
+            self._aliases.pop(session_id, None)
+        self._save_aliases()
+
+    def _load_files(self) -> None:
+        try:
+            raw = FILE_HISTORY_PATH.read_text(encoding="utf-8")
+        except FileNotFoundError:
+            return
+        obj = json.loads(raw)
+        if not isinstance(obj, dict):
+            raise ValueError("invalid session_files.json (expected object)")
+        cleaned: dict[str, list[str]] = {}
+        for sid, arr in obj.items():
+            if not isinstance(sid, str) or not sid:
+                continue
+            key = sid if (sid.startswith("cwd:") or sid.startswith("sid:")) else f"sid:{sid}"
+            if not isinstance(arr, list):
+                continue
+            out: list[str] = []
+            for v in arr:
+                if not isinstance(v, str):
+                    continue
+                p = v.strip()
+                if not p or p in out:
+                    continue
+                out.append(p)
+                if len(out) >= FILE_HISTORY_MAX:
+                    break
+            if out:
+                cleaned[key] = out
+        with self._lock:
+            self._files = cleaned
+
+    def _save_files(self) -> None:
+        with self._lock:
+            obj = dict(self._files)
+        os.makedirs(APP_DIR, exist_ok=True)
+        tmp = FILE_HISTORY_PATH.with_suffix(".json.tmp")
+        tmp.write_text(json.dumps(obj, ensure_ascii=False, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+        os.replace(tmp, FILE_HISTORY_PATH)
+
+    def _files_key_for_session(self, session_id: str) -> tuple[str, list[str], "Session"]:
+        s = self._sessions.get(session_id)
+        if not s:
+            raise KeyError("unknown session")
+        cwd_key: str | None = None
+        cwd_raw = s.cwd if isinstance(s.cwd, str) else ""
+        if cwd_raw and cwd_raw != "?":
+            try:
+                cwd_norm = str(Path(cwd_raw).expanduser().resolve())
+            except Exception:
+                cwd_norm = cwd_raw.strip()
+            if cwd_norm:
+                cwd_key = f"cwd:{cwd_norm}"
+        sid_key = f"sid:{session_id}"
+        if cwd_key:
+            legacy = [sid_key, session_id]
+            return cwd_key, legacy, s
+        return sid_key, [session_id], s
+
+    def files_get(self, session_id: str) -> list[str]:
+        dirty = False
+        out: list[str] = []
+        with self._lock:
+            key, legacy_keys, _s = self._files_key_for_session(session_id)
+            arr = self._files.get(key)
+            if isinstance(arr, list) and arr:
+                out = list(arr)
+            else:
+                for lk in legacy_keys:
+                    arr2 = self._files.get(lk)
+                    if isinstance(arr2, list) and arr2:
+                        out = list(arr2)
+                        if lk != key:
+                            self._files[key] = list(arr2)
+                            self._files.pop(lk, None)
+                            dirty = True
+                        break
+        if dirty:
+            self._save_files()
+        return list(out)
+
+    def files_add(self, session_id: str, path: str) -> list[str]:
+        p = str(path).strip()
+        if not p:
+            return self.files_get(session_id)
+        dirty = False
+        with self._lock:
+            key, legacy_keys, _s = self._files_key_for_session(session_id)
+            cur = list(self._files.get(key, []))
+            if not cur:
+                for lk in legacy_keys:
+                    legacy = self._files.get(lk)
+                    if isinstance(legacy, list) and legacy:
+                        cur = list(legacy)
+                        if lk != key:
+                            self._files.pop(lk, None)
+                            dirty = True
+                        break
+            cur = [x for x in cur if x != p]
+            cur.insert(0, p)
+            if len(cur) > FILE_HISTORY_MAX:
+                cur = cur[:FILE_HISTORY_MAX]
+            self._files[key] = cur
+        self._save_files()
+        return list(cur)
+
+    def files_clear(self, session_id: str) -> None:
+        dirty = False
+        with self._lock:
+            key, legacy_keys, s = self._files_key_for_session(session_id)
+            for lk in legacy_keys:
+                if lk in self._files:
+                    self._files.pop(lk, None)
+                    dirty = True
+            if key.startswith("cwd:"):
+                keep = False
+                for other in self._sessions.values():
+                    if other.session_id == s.session_id:
+                        continue
+                    try:
+                        other_key, _legacy, _s2 = self._files_key_for_session(other.session_id)
+                    except KeyError:
+                        continue
+                    if other_key == key:
+                        keep = True
+                        break
+                if not keep and key in self._files:
+                    self._files.pop(key, None)
+                    dirty = True
+            else:
+                if key in self._files:
+                    self._files.pop(key, None)
+                    dirty = True
+        if dirty:
+            self._save_files()
 
     def harness_get(self, session_id: str) -> dict[str, Any]:
         with self._lock:
@@ -1031,11 +1249,35 @@ class SessionManager:
         self._discover_existing_if_stale()
         self._prune_dead_sessions()
         self._update_meta_counters()
+        files_dirty = False
         with self._lock:
             items: list[dict[str, Any]] = []
             for s in self._sessions.values():
                 cfg0 = self._harness.get(s.session_id)
                 h_enabled = bool(cfg0.get("enabled")) if isinstance(cfg0, dict) else False
+                alias = self._aliases.get(s.session_id)
+                if not isinstance(alias, str):
+                    alias = ""
+                files: list[str] = []
+                try:
+                    key, legacy_keys, _sref = self._files_key_for_session(s.session_id)
+                except KeyError:
+                    key = ""
+                    legacy_keys = []
+                if key:
+                    cur = self._files.get(key)
+                    if isinstance(cur, list) and cur:
+                        files = list(cur)
+                    else:
+                        for lk in legacy_keys:
+                            legacy = self._files.get(lk)
+                            if isinstance(legacy, list) and legacy:
+                                files = list(legacy)
+                                if lk != key:
+                                    self._files[key] = list(legacy)
+                                    self._files.pop(lk, None)
+                                    files_dirty = True
+                                break
                 log_exists = bool(s.log_path is not None and s.log_path.exists())
                 if s.last_chat_ts is None and log_exists and s.log_path is not None:
                     s.last_chat_ts = float(s.log_path.stat().st_mtime)
@@ -1059,6 +1301,8 @@ class SessionManager:
                         "tools": int(s.meta_tools),
                         "system": int(s.meta_system),
                         "harness_enabled": h_enabled,
+                        "alias": alias,
+                        "files": list(files),
                     }
                 )
 
@@ -1078,6 +1322,8 @@ class SessionManager:
             it2.pop("state_busy", None)
             it2["busy"] = bool(busy_out)
             out.append(it2)
+        if files_dirty:
+            self._save_files()
         return out
 
     def get_session(self, session_id: str) -> Session | None:
@@ -1390,7 +1636,11 @@ class SessionManager:
             return False
         if not s.owned:
             raise PermissionError("not owned by web")
-        return self.kill_session(session_id)
+        ok = self.kill_session(session_id)
+        if ok:
+            self.alias_clear(session_id)
+            self.files_clear(session_id)
+        return ok
 
     def send(self, session_id: str, text: str) -> dict[str, Any]:
         with self._lock:
@@ -1874,6 +2124,50 @@ class Handler(http.server.BaseHTTPRequestHandler):
                 _json_response(self, 200, {"ok": True, **res})
                 return
 
+            if path == "/api/files/read":
+                if not _require_auth(self):
+                    self._unauthorized()
+                    return
+                body = _read_body(self)
+                body_text = body.decode("utf-8")
+                if not body_text.strip():
+                    raise ValueError("empty request body")
+                obj = json.loads(body_text)
+                if not isinstance(obj, dict):
+                    raise ValueError("invalid json body (expected object)")
+                path_raw = obj.get("path")
+                if not isinstance(path_raw, str) or not path_raw.strip():
+                    _json_response(self, 400, {"error": "path required"})
+                    return
+                session_id_raw = obj.get("session_id")
+                session_id = session_id_raw if isinstance(session_id_raw, str) and session_id_raw else ""
+                path_obj = Path(path_raw).expanduser()
+                if not path_obj.is_absolute():
+                    path_obj = (Path.cwd() / path_obj).resolve()
+                else:
+                    path_obj = path_obj.resolve()
+                if not path_obj.exists():
+                    _json_response(self, 404, {"error": "file not found"})
+                    return
+                if not path_obj.is_file():
+                    _json_response(self, 400, {"error": "path is not a file"})
+                    return
+                try:
+                    text, size = _read_text_file_strict(path_obj, max_bytes=FILE_READ_MAX_BYTES)
+                except PermissionError:
+                    _json_response(self, 403, {"error": "permission denied"})
+                    return
+                except ValueError as e:
+                    _json_response(self, 400, {"error": str(e)})
+                    return
+                if session_id:
+                    try:
+                        MANAGER.files_add(session_id, str(path_obj))
+                    except KeyError:
+                        pass
+                _json_response(self, 200, {"ok": True, "path": str(path_obj), "size": int(size), "text": text})
+                return
+
             if path.startswith("/api/sessions/") and path.endswith("/delete"):
                 if not _require_auth(self):
                     self._unauthorized()
@@ -1893,6 +2187,31 @@ class Handler(http.server.BaseHTTPRequestHandler):
                     _json_response(self, 404, {"error": "unknown session"})
                     return
                 _json_response(self, 200, {"ok": True})
+                return
+
+            if path.startswith("/api/sessions/") and path.endswith("/rename"):
+                if not _require_auth(self):
+                    self._unauthorized()
+                    return
+                parts = path.split("/")
+                session_id = parts[3] if len(parts) >= 4 else ""
+                body = _read_body(self)
+                body_text = body.decode("utf-8")
+                if not body_text.strip():
+                    raise ValueError("empty request body")
+                obj = json.loads(body_text)
+                if not isinstance(obj, dict):
+                    raise ValueError("invalid json body (expected object)")
+                name = obj.get("name")
+                if not isinstance(name, str):
+                    _json_response(self, 400, {"error": "name required"})
+                    return
+                try:
+                    alias = MANAGER.alias_set(session_id, name)
+                except KeyError:
+                    _json_response(self, 404, {"error": "unknown session"})
+                    return
+                _json_response(self, 200, {"ok": True, "alias": alias})
                 return
 
             if path.startswith("/api/sessions/") and path.endswith("/send"):

--- a/scripts/codoxear-resume
+++ b/scripts/codoxear-resume
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_DIR="${CODEX_WEB_APP_DIR:-$HOME/.local/share/codoxear}"
+SOCK_DIR="${APP_DIR}/socks"
+
+usage() {
+  cat <<'EOF'
+Usage: codoxear-resume [--list] [--last] [--id <session_id>] [--web | --terminal]
+
+Interactive helper to resume Codex sessions from Codoxear metadata.
+
+Options:
+  --list        List available sessions and exit
+  --last        Resume most recent session via codex
+  --id <id>     Resume specific session id
+  --web         Show only web-owned sessions
+  --terminal    Show only terminal-owned sessions
+EOF
+}
+
+if ! command -v codex >/dev/null 2>&1; then
+  echo "error: codex CLI not found in PATH" >&2
+  exit 1
+fi
+
+mode="interactive"
+filter_owner=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --last)
+      exec codex resume --last
+      ;;
+    --id)
+      if [[ -z "${2:-}" ]]; then
+        echo "error: --id requires a session id" >&2
+        exit 1
+      fi
+      exec codex resume "$2"
+      ;;
+    --list)
+      mode="list"
+      shift
+      ;;
+    --web)
+      filter_owner="web"
+      shift
+      ;;
+    --terminal)
+      filter_owner="terminal"
+      shift
+      ;;
+    *)
+      echo "error: unknown argument $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ ! -d "$SOCK_DIR" ]]; then
+  echo "error: no sessions dir at $SOCK_DIR" >&2
+  exit 1
+fi
+
+list_sessions() {
+  SOCK_DIR="$SOCK_DIR" FILTER_OWNER="$filter_owner" python3 - <<'PY'
+import json
+import os
+import time
+from pathlib import Path
+
+sock_dir = Path(os.environ["SOCK_DIR"])
+filter_owner = os.environ.get("FILTER_OWNER", "").strip()
+items = []
+for meta_path in sorted(sock_dir.glob("*.json")):
+    try:
+        meta = json.loads(meta_path.read_text(encoding="utf-8"))
+    except Exception:
+        continue
+    sid = meta.get("session_id") or meta_path.stem
+    if not isinstance(sid, str) or not sid.strip():
+        sid = meta_path.stem
+    owner = meta.get("owner") if isinstance(meta.get("owner"), str) else "terminal"
+    if filter_owner and owner != filter_owner:
+        continue
+    cwd = meta.get("cwd") if isinstance(meta.get("cwd"), str) else "?"
+    start_ts = meta.get("start_ts")
+    ts = float(start_ts) if isinstance(start_ts, (int, float)) else 0.0
+    start = time.strftime("%Y-%m-%d %H:%M", time.localtime(ts)) if ts > 0 else "?"
+    items.append((sid, owner, cwd, start, ts))
+
+items.sort(key=lambda x: x[4], reverse=True)
+for i, (sid, owner, cwd, start, _ts) in enumerate(items, 1):
+    print(f"{i}\t{sid}\t{owner}\t{cwd}\t{start}")
+PY
+}
+
+lines="$(list_sessions)"
+if [[ -z "$lines" ]]; then
+  echo "no sessions found in $SOCK_DIR" >&2
+  exit 1
+fi
+
+if [[ "$mode" == "list" ]]; then
+  printf "Idx\tSession ID\tOwner\tCWD\tStarted\n"
+  printf "%s\n" "$lines" | sed 's/\t/  /g'
+  exit 0
+fi
+
+printf "Idx  Session ID                           Owner     CWD                           Started\n"
+printf "%s\n" "$lines" | awk -F'\t' '{printf "%-4s %-36s %-9s %-28s %s\n", $1, $2, $3, $4, $5}'
+printf "\nSelect session number (blank to cancel): "
+read -r choice
+if [[ -z "${choice// }" ]]; then
+  exit 0
+fi
+if ! [[ "$choice" =~ ^[0-9]+$ ]]; then
+  echo "error: invalid choice" >&2
+  exit 1
+fi
+
+sid="$(printf "%s\n" "$lines" | awk -F'\t' -v n="$choice" '$1==n {print $2; exit}')"
+if [[ -z "$sid" ]]; then
+  echo "error: no session for selection $choice" >&2
+  exit 1
+fi
+
+exec codex resume "$sid"

--- a/tests/test_sessions_pending_log_idle.py
+++ b/tests/test_sessions_pending_log_idle.py
@@ -11,6 +11,8 @@ def _make_manager() -> SessionManager:
     mgr._lock = threading.Lock()
     mgr._sessions = {}
     mgr._harness = {}
+    mgr._aliases = {}
+    mgr._files = {}
     mgr._discover_existing_if_stale = lambda *args, **kwargs: None  # type: ignore[method-assign]
     mgr._prune_dead_sessions = lambda *args, **kwargs: None  # type: ignore[method-assign]
     mgr._update_meta_counters = lambda *args, **kwargs: None  # type: ignore[method-assign]
@@ -42,4 +44,3 @@ class TestSessionsPendingLogIdle(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-


### PR DESCRIPTION
## Summary
- Add file history tracking and file viewer API endpoint.
- Share file history across sessions that use the same working directory.
- Mark sessions busy on web sends to avoid premature queue release.
- Add scripts/codoxear-resume helper.
- Update AGENTS.md ops notes.

## Notes
- No UI changes in this PR.