### PR TITLE
Fix macOS rollout log discovery

### DIFF
--- a/codoxear/util.py
+++ b/codoxear/util.py
@@ -336,7 +336,7 @@ def proc_open_rollout_logs(proc_root: Path, root_pid: int) -> set[Path]:
 
 def proc_open_writable_rollout_logs(proc_root: Path, root_pid: int) -> set[Path]:
     if sys.platform == "darwin":
-        return set()
+        return _macos_open_rollout_logs(root_pid)
     uid = int(os.getuid())
     out: set[Path] = set()
     for pid in _proc_descendants(proc_root, root_pid):


### PR DESCRIPTION
## Summary

- On macOS, `proc_open_writable_rollout_logs` was returning an empty `set()`, so the broker's `_log_discover_watcher` could never find the active rollout log
- Sessions ended up with `log_path = None`, meaning the browser received no chat events and message sends appeared to have no response (silent failure on mobile)
- Fix: delegate to `_macos_open_rollout_logs` (lsof-based) on darwin, consistent with `proc_open_rollout_logs` and the original macos-support behavior

## Root Cause

`origin/main` changed `proc_find_open_rollout_log` to use `proc_open_writable_rollout_logs` instead of `proc_open_rollout_logs`. The writable variant had `if sys.platform == "darwin": return set()` as a placeholder, which broke log discovery on macOS entirely.

## Test plan

- [ ] Create a new session on macOS after this fix
- [ ] Verify `log_path` is non-null in `/api/sessions` response
- [ ] Confirm chat messages and responses appear in the browser (mobile and desktop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)